### PR TITLE
blurhash v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Drop IE11 support
+
 ## 0.1.1 (July 1, 2019)
 
 - `Blurhash` component's `width` and `height` can now also be a string (CSS property)

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ts:watch": "npm run ts -- --noEmit --watch"
   },
   "peerDependencies": {
-    "blurhash": "^1.1.1",
+    "blurhash": "^2.0.3",
     "react": ">=15"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
     "@types/styled-components": "^5.1.4",
-    "blurhash": "^1.1.2",
+    "blurhash": "^2.0.3",
     "html-webpack-plugin": "^4.5.0",
     "prettier": "2.1.2",
     "react": "^16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -688,10 +688,10 @@ bluebird@^3.5.5:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-blurhash@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-1.1.2.tgz#0a106b739d212d399101b688211550db286074bc"
-  integrity sha512-W5OMsNgsLBJw2A+gL03LlN+WN36V9f0DVyzuum+dQc3iJWua/JSAz20JTweWoNAZ1KubGpCKFan1Tr6481mPQA==
+blurhash@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/blurhash/-/blurhash-2.0.3.tgz#5c1166bf5b65e09e337fe5b8c6b53e1218085b0b"
+  integrity sha512-nTnJTOheiaV3b189f7rH5AbbrnQB2r3CcOZBg47GUDaE9DrxyBPD2w0HYp4ME2UBlTP7LMIa6nMWqg/58oyIzA==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.4.0:
   version "4.11.9"


### PR DESCRIPTION
Close #37.
This version drops IE11 support, so we need to release it as `v0.2.0`.